### PR TITLE
Permit empty stringified permitted hash

### DIFF
--- a/spec/fixtures/manifests/site.pp
+++ b/spec/fixtures/manifests/site.pp
@@ -40,3 +40,5 @@ node 'disable-mechanism' {
   change_risk('test')
   notify { 'test': }
 }
+
+node default { }

--- a/spec/type_aliases/permitted_spec.rb
+++ b/spec/type_aliases/permitted_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'Change_risk::Permitted' do
+  it { is_expected.to allow_value({"high" => false, "low" => true}) }
+  it { is_expected.to allow_value({}) }
+  it { is_expected.to allow_value('{"high" => false, "low" => true}') }
+  it { is_expected.to allow_value('{}') }
+  it { is_expected.not_to allow_value('{"boolean" => "false"}') }
+end

--- a/types/permitted.pp
+++ b/types/permitted.pp
@@ -1,4 +1,4 @@
 type Change_risk::Permitted = Variant[
   Hash[String, Change_risk::Boolean],
-  Pattern[/^{(['"][\w-]*['"] *=> *(true|false)(, *)?)+}$/]
+  Pattern[/^{((['"][\w-]*['"] *=> *(true|false)(, *)?)+)?}$/]
 ]


### PR DESCRIPTION
This commit modifies the string regex for Change_risk::Permitted to allow an empty hash